### PR TITLE
Restrict base YAML dialect to the core schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ for (let name of supportedFunctions) {
  * The actual js-yaml schema, extending the DEFAULT_SAFE_SCHEMA.
  */
 const schema = new jsYaml.Schema({
-  include: [ jsYaml.DEFAULT_SAFE_SCHEMA ],
+  include: [ jsYaml.CORE_SCHEMA ],
   implicit: [],
   explicit: allTagTypes,
 });

--- a/test/test-main.js
+++ b/test/test-main.js
@@ -102,4 +102,22 @@ describe('yaml-schema', function() {
     assert.deepEqual(yamlParse(input), parsed);
     assert.deepEqual(yamlParse(yamlDump(parsed)), parsed);
   });
+
+  it("should parse date-like strings as strings", function() {
+    const input = `
+    Key:
+    - 2001-11-01
+    - '2001-11-02'
+    `;
+
+    const parsed = {
+      "Key": [
+        "2001-11-01",
+        "2001-11-02"
+      ]
+    };
+
+    assert.deepEqual(yamlParse(input), parsed);
+    assert.deepEqual(yamlParse(yamlDump(parsed)), parsed);
+  });
 });


### PR DESCRIPTION
Fixes #8.

This aligns with the CFN YAML support defined by:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-formats.html